### PR TITLE
Fix Azure Function payload returns Url

### DIFF
--- a/azurefunctions-extension-bala/code.bal
+++ b/azurefunctions-extension-bala/code.bal
@@ -535,7 +535,7 @@ public isolated function getHTTPRequestFromInputData(HandlerParams params, strin
     json idx = check hreq.Identities;
     json identitiesTemp = check parseJson(idx.toJsonString());
     json[] identities = <json[]> identitiesTemp;
-    var bodyVal = hreq.Url;
+    var bodyVal = hreq.Body;
     string body = bodyVal is error ? bodyVal.toString() : bodyVal.toString();
     HTTPRequest req = { url: url, method: method, query: query, headers: headers, 
                         params: hparams, identities: identities, body: body };


### PR DESCRIPTION
## Purpose
Fixed the Bug where you get Url as the payload variable in the below function.

Resolves #78

```ballerina
import ballerinax/azure_functions as af;

// HTTP request/response with no authentication
@af:Function
public function hello(@af:HTTPTrigger { authLevel: "anonymous" } string payload) 
                      returns @af:HTTPOutput string|error {
    return "Hello, " + payload + "!";
}

```
